### PR TITLE
Don't assume the presence of the debugging lib and copy gio-sharp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ EXTRA_BUNDLE = $(GIOSHARP_ASSEMBLIES)
 
 install-data-hook:
 	for ASM in $(GIOSHARP_ASSEMBLIES); do \
-        $(INSTALL) -m 0755 $$ASM $(beansdir); \
+        $(INSTALL_DATA) $$ASM $(beansdir); \
     done;
 
 uninstall-hook:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = sources
+
 UNSAFE = -unsafe
 DEBUG = -debug
 
@@ -63,6 +65,18 @@ beans_DATA = gtk-sharp-beans.dll gtk-sharp-beans.dll.mdb gtk-sharp-beans.dll.con
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = gtk-sharp-beans-2.0.pc
+
+EXTRA_BUNDLE = $(GIOSHARP_ASSEMBLIES)
+
+install-data-hook:
+	for ASM in $(GIOSHARP_ASSEMBLIES); do \
+        $(INSTALL) -m 0755 $$ASM $(beansdir); \
+    done;
+
+uninstall-hook:
+	for ASM in $(GIOSHARP_ASSEMBLIES); do \
+        rm -f $(beansdir)/`basename $$ASM`; \
+    done;
 
 CLEANFILES = 			\
 	gtk-sharp-beans.dll 	\

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,14 @@ PKG_CHECK_MODULES(GLIBSHARP, glib-sharp-2.0 >= 2.12)
 PKG_CHECK_MODULES(GIOSHARP, gio-sharp-2.0 >= 2.18)
 PKG_CHECK_MODULES(GAPI, gapi-2.0 >= 2.12.0)
 
+asms="`$PKG_CONFIG --variable=Libraries gio-sharp-2.0`"
+for asm in $asms; do
+	GIOSHARP_ASSEMBLIES="$GIOSHARP_ASSEMBLIES $asm"
+	[[ -r "$asm.mdb" ]] && GIOSHARP_ASSEMBLIES="$GIOSHARP_ASSEMBLIES $asm.mdb"
+	[[ -r "$asm.config" ]] && GIOSHARP_ASSEMBLIES="$GIOSHARP_ASSEMBLIES $asm.config"
+done
+AC_SUBST(GIOSHARP_ASSEMBLIES)
+
 CSC_DEFINES=""
 if pkg-config --atleast-version=2.16 gtk+-2.0; then
 	CSC_DEFINES="$CSC_DEFINES -d:GTK_2_16"
@@ -43,6 +51,7 @@ AC_SUBST(LIB_SUFFIX)
 
 AC_OUTPUT(
 Makefile 
+sources/Makefile
 gtk-sharp-beans-2.0.pc
 gtk-sharp-beans.dll.config
 AssemblyInfo.cs

--- a/gtk-sharp-beans-2.0.pc.in
+++ b/gtk-sharp-beans-2.0.pc.in
@@ -3,7 +3,7 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 assemblies_dir=${libdir}/gtk-sharp-beans
 gapidir=${prefix}/share/gapi-2.0
-Libraries=${assemblies_dir}/gtk-sharp-beans.dll ${assemblies_dir}/gtk-sharp-beans.dll.mdb
+Libraries=${assemblies_dir}/gtk-sharp-beans.dll
 
 Name: Gtk#Beans
 Description: Gtk#Beans - Blings and API missing from Gtk#

--- a/gtk-sharp-beans-2.0.pc.in
+++ b/gtk-sharp-beans-2.0.pc.in
@@ -3,7 +3,7 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 assemblies_dir=${libdir}/gtk-sharp-beans
 gapidir=${prefix}/share/gapi-2.0
-Libraries=${assemblies_dir}/gtk-sharp-beans.dll
+Libraries=${assemblies_dir}/gtk-sharp-beans.dll ${assemblies_dir}/gio-sharp.dll
 
 Name: Gtk#Beans
 Description: Gtk#Beans - Blings and API missing from Gtk#


### PR DESCRIPTION
This is similar to my previous gio-sharp patch to not assume the .mdb file is present.

Also gtk-sharp-beans depends on the non-GACed gio-sharp, so it should copy these libraries at install time too.

There is a corresponding patch to Banshee's buildsystem which I will submit if and when this patch is merged.

It is worth noting that the install-data-hook I added causes make distcheck to fail, and I don't quite know how to fix it. make dist, and the resulting library still work though.

Cheers.
Iain
